### PR TITLE
Mount X11 socket

### DIFF
--- a/usr/bin/sandbox-app-launcher
+++ b/usr/bin/sandbox-app-launcher
@@ -115,6 +115,7 @@ run_program() {
   --remount-ro ${main_app_dir} \
   --proc /proc \
   --tmpfs /tmp \
+  --ro-bind /tmp/.X11-unix /tmp/.X11-unix \
   --tmpfs /var/tmp \
   --tmpfs /var/cache \
   --tmpfs /var/run \


### PR DESCRIPTION
When using a network namespace (`allow_net=no`) and an empty tmpfs (`--tmpfs /tmp`), the app has no way to connect to the X11 server (and thus no GUI). This mounts the X11 socket in /tmp so apps can still use it.