### PR TITLE
Get rid of create_symlinks()

### DIFF
--- a/usr/bin/sandbox-app-launcher
+++ b/usr/bin/sandbox-app-launcher
@@ -8,6 +8,7 @@ symlink_dir="${main_app_dir}/symlinks"
 app_name="${*}"
 app_user="sandbox-${app_name}"
 app_homedir="${main_app_dir}/${app_name}"
+app_path="$(type -P ${app_name})"
 seccomp_filter="${main_app_dir}/seccomp-filter.bpf"
 wx_whitelist="${main_app_dir}/wx_whitelist"
 
@@ -16,6 +17,11 @@ if [ -f "/etc/sandbox-app-launcher/${app_name}.conf" ]; then
 fi
 
 setup() {
+  if ! [ -e "${app_path}" ]; then
+    echo "ERROR: Could not find '${app_name}' in \$PATH."
+    exit 1
+  fi
+
   if ! [ -d "${main_app_dir}" ]; then
     mkdir -m 755 "${main_app_dir}"
   fi
@@ -54,16 +60,8 @@ setup() {
   if grep -qw "${app_name}" "${wx_whitelist}"; then
     seccomp_filter="${main_app_dir}/seccomp-filter-wx.bpf"
   fi
-}
 
-create_symlinks() {
-  app_path="$(type -P ${app_name})"
-
-  if ! [ -e "${app_path}" ]; then
-    echo "ERROR: Could not find '${app_name}' in \$PATH."
-    exit 1
-  fi
-
+  ## Create symlinks.
   if ! [ -e "${symlink_dir}/${app_name}" ]; then
     ln -s "${app_path}" "${symlink_dir}/${app_name}"
   fi
@@ -148,5 +146,4 @@ run_program() {
 }
 
 setup
-create_symlinks
 run_program


### PR DESCRIPTION
There's no point in having this in a different function from setup() and it allows us to move the $PATH check further up so the users aren't created if the program doesn't exist.