### PR TITLE
Add shared storage

### DIFF
--- a/etc/apparmor.d/sandbox-app-launcher
+++ b/etc/apparmor.d/sandbox-app-launcher
@@ -13,6 +13,8 @@ profile sandbox-app-launcher @{SYMLINK_DIR}/** flags=(attach_disconnected) {
   ## executing their own code.
   owner @{MAIN_APP_DIR}/*/ rw,
   owner @{MAIN_APP_DIR}/*/** rwlk,
+  /shared/ rw,
+  /shared/** rwlk,
 
   ## Allow us to send ourselves signals.
   ## TODO: Whitelist of allowed signals.

--- a/usr/bin/sandbox-app-launcher
+++ b/usr/bin/sandbox-app-launcher
@@ -26,7 +26,7 @@ setup() {
   fi
 
   if ! [ -d "${shared_dir}" ]; then
-    mkdir -m 777 "${shared_dir}"
+    mkdir -m 1777 "${shared_dir}"
   fi
 
   if ! getent passwd | sed -e 's/:.*//g' | grep -qw "${app_user}"; then

--- a/usr/bin/sandbox-app-launcher
+++ b/usr/bin/sandbox-app-launcher
@@ -10,6 +10,7 @@ app_user="sandbox-${app_name}"
 app_homedir="${main_app_dir}/${app_name}"
 seccomp_filter="${main_app_dir}/seccomp-filter.bpf"
 wx_whitelist="${main_app_dir}/wx_whitelist"
+shared_dir="/shared"
 
 if [ -f "/etc/sandbox-app-launcher/${app_name}.conf" ]; then
   . "/etc/sandbox-app-launcher/${app_name}.conf"
@@ -22,6 +23,10 @@ setup() {
 
   if ! [ -d "${symlink_dir}" ]; then
     mkdir -m 755 "${symlink_dir}"
+  fi
+
+  if ! [ -d "${shared_dir}" ]; then
+    mkdir -m 777 "${shared_dir}"
   fi
 
   if ! getent passwd | sed -e 's/:.*//g' | grep -qw "${app_user}"; then
@@ -87,6 +92,13 @@ run_program() {
   ## Optionally remove network access by creating an empty net namespace.
   if [ "${allow_net}" = "no" ]; then
     bwrap_args+="--unshare-net "
+  fi
+
+  ## Shared storage.
+  if [ "${shared_storage}" = "read-write" ]; then
+    bwrap_args+="--bind ${shared_dir} ${shared_dir} "
+  elif [ "${shared_storage}" = "read-only" ]; then
+    bwrap_args+="--ro-bind ${shared_dir} ${shared_dir} "
   fi
 
   sudo -H -u "${app_user}" bash -c "


### PR DESCRIPTION
This creates a world-writable directory to share files across the sandbox. Access to it can be configured via /etc/sandbox-app-launcher.

We should also make a shortcut in the file manager so apps can easily access it but I don't know how to do that.