### PR TITLE
Add some tests

### DIFF
--- a/tests/W^X/w^x-mmap.c
+++ b/tests/W^X/w^x-mmap.c
@@ -1,0 +1,26 @@
+/*
+
+W^X - mmap(), mmap2()
+
+A memory mapping that is both writable and executable at the same time (PROT_WRITE|PROT_EXEC)
+is dangerous because an attacker can write arbitrary code there to be executed.
+
+This tries to create a memory mapping that is both writable and executable.
+This also tests for mmap2() (an alternative to mmap()).
+
+The seccomp filter enforces strict W^X restrictions that should prevent this.
+
+Expected output:
+
+Bad system call (core dumped)
+
+*/
+
+#include <sys/syscall.h>
+#include <sys/mman.h>
+#include <stddef.h>
+
+int main() {
+  mmap(NULL, 128, PROT_WRITE|PROT_EXEC, MAP_PRIVATE, -1, 0);
+  mmap2(NULL, 128, PROT_WRITE|PROT_EXEC, MAP_PRIVATE, -1, 0);
+}

--- a/tests/W^X/w^x-mprotect.c
+++ b/tests/W^X/w^x-mprotect.c
@@ -1,0 +1,28 @@
+/*
+
+W^X - mprotect(), pkey_mprotect()
+
+An attacker can write arbitary code to a writable memory mapping and then make the
+mapping executable via mprotect(). This can bypass any mmap() restrictions.
+
+This attempts to create a writable memory mapping then mprotect() it to executable.
+This also tests for pkey_mprotect() (an alternative to mprotect()).
+
+The seccomp filter enforces strict W^X restrictions that should prevent this.
+
+Expected output:
+
+Bad system call (core dumped)
+
+*/
+
+#include <sys/mman.h>
+#include <stdlib.h>
+
+int main() {
+  char* test = malloc(128);
+  mmap(test, 128, PROT_WRITE, MAP_PRIVATE, -1, 0);
+  test[0] = '\xcc';
+  mprotect(test, 128, PROT_READ|PROT_EXEC);
+  pkey_mprotect(test, 128, PROT_READ|PROT_EXEC);
+}

--- a/tests/W^X/w^x-shmat.c
+++ b/tests/W^X/w^x-shmat.c
@@ -1,0 +1,21 @@
+/*
+
+W^X - shmat()
+
+The shmat() syscall can be used to map shared memory segments as executable.
+
+The seccomp filter enforces strict W^X restrictions that should prevent this.
+
+Expected output:
+
+Bad system call (core dumped)
+
+*/
+
+#include <sys/types.h>
+#include <sys/shm.h>
+#include <stddef.h>
+
+int main() {
+  shmat(1, NULL, SHM_EXEC);
+}

--- a/tests/exec-elf.sh
+++ b/tests/exec-elf.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+## Test executing an ELF binary. This will be stopped by AppArmor's execution restrictions.
+##
+## Expected output:
+##
+## bash: ~/exec-elf: Permission denied
+##
+echo "#include <stdio.h>
+int main () {
+  printf(\"test\");
+}" > ~/exec-elf.c
+gcc ~/exec-elf.c -o ~/exec-elf
+~/exec-elf

--- a/tests/tiocsti.c
+++ b/tests/tiocsti.c
@@ -1,0 +1,40 @@
+/*
+
+TIOCSTI is a common sandbox escape method. The following code attempts to call the TIOCSTI ioctl
+and should be stopped by the seccomp filter. Even if the ioctl was allowed in the seccomp filter,
+bubblewrap's "--new-session" flag would prevent it from being used to escape.
+
+Expected output with seccomp:
+
+Bad system call (core dumped)
+
+Expected output without seccomp (with just --new-session):
+
+normal TIOCSTI: -1 (Operation not permitted)
+high-bit-set TIOCSTI: -1 (Operation not permitted)
+
+https://www.exploit-db.com/exploits/46594
+
+*/
+
+#define _GNU_SOURCE
+#include <termios.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <errno.h>
+
+static int ioctl64(int fd, unsigned long nr, void *arg) {
+  errno = 0;
+  return syscall(__NR_ioctl, fd, nr, arg);
+}
+
+int main(void) {
+  int res;
+  char pushmeback = '#';
+  res = ioctl64(0, TIOCSTI, &pushmeback);
+  printf("normal TIOCSTI: %d (%m)\n", res);
+  res = ioctl64(0, TIOCSTI | (1UL<<32), &pushmeback);
+  printf("high-bit-set TIOCSTI: %d (%m)\n", res);
+}


### PR DESCRIPTION
This adds a few tests to test the sandboxing.

tiocsti.c: tries to use the TIOCSTI ioctl which will be stopped by `--new-session` and/or seccomp

exec-elf.sh: tries to create an ELF binary and execute it which will be stopped by AppArmor

W^X: 3 tests to try to write arbitary code to a memory mapping and execute it which will be stopped by seccomp