### PR TITLE
Let apps setup further sandboxing beyond sandbox-app-launcher

### DIFF
--- a/etc/apparmor.d/sandbox-app-launcher
+++ b/etc/apparmor.d/sandbox-app-launcher
@@ -11,6 +11,11 @@
 profile sandbox-app-launcher @{WRAPPER_DIR}/** flags=(attach_disconnected) {
   / r,
 
+  ## Needed for apps to setup further sandboxing like Firefox/Chromium.
+  capability sys_admin,
+  capability sys_chroot,
+  capability sys_ptrace,
+
   ## Let the app do whatever they want with their own data except
   ## executing their own code.
   owner @{HOME_DIR}/*/ rw,

--- a/usr/share/sandbox-app-launcher/seccomp.c
+++ b/usr/share/sandbox-app-launcher/seccomp.c
@@ -43,6 +43,7 @@ int main(int argc, char *argv[])
     ALLOW_SYSCALL (chmod);
     ALLOW_SYSCALL (chown);
     ALLOW_SYSCALL (chown32);
+    ALLOW_SYSCALL (chroot);
     ALLOW_SYSCALL (clock_getres);
     ALLOW_SYSCALL (clock_gettime);
     ALLOW_SYSCALL (clock_nanosleep);


### PR DESCRIPTION
This is needed for e.g. the Firefox and Chromium browser sandbox.