### PR TITLE
Don't create seccomp-whitelist-wx in the script

### DIFF
--- a/usr/bin/sandbox-app-launcher
+++ b/usr/bin/sandbox-app-launcher
@@ -100,10 +100,6 @@ setup() {
   fi
 
   if ! [ -f "${main_app_dir}/seccomp-filter-wx.bpf" ]; then
-    cp "${main_app_dir}/seccomp-whitelist" "${auto_dir}/seccomp-whitelist-wx"
-    for replace_syscall in mmap mmap2 mprotect pkey_mprotect shmat; do
-      str_replace "#${replace_syscall}" "${replace_syscall}" "${auto_dir}/seccomp-whitelist-wx" >/dev/null
-    done
     "${main_app_dir}/autogen-seccomp" "${auto_dir}/seccomp-whitelist-wx" > "${auto_dir}/seccomp-wx.c"
     str_replace "seccomp-filter.bpf" "seccomp-filter-wx.bpf" "${auto_dir}/seccomp-wx.c" >/dev/null
     gcc "${auto_dir}/seccomp-wx.c" -o "${auto_dir}/seccomp-wx" ${compiler_flags}

--- a/usr/share/sandbox-app-launcher/autogen-seccomp
+++ b/usr/share/sandbox-app-launcher/autogen-seccomp
@@ -16,50 +16,59 @@ if ! [ -f "${whitelist_file}" ]; then
   exit 1
 fi
 
-while read -r syscall; do
-  actual_syscall=""
-  arg_num=""
-  syscall_arg=""
-  arg_rule=""
+generate_filter() {
+  while read -r syscall; do
+    actual_syscall=""
+    arg_num=""
+    syscall_arg=""
+    arg_rule=""
 
-  if [[ "${syscall}" =~ ^# ]]; then
-    continue
-  fi
+    if [[ "${syscall}" =~ ^# ]]; then
+      continue
+    fi
 
-  if [ "${syscall}" = "" ]; then
-    continue
-  fi
+    if [ "${syscall}" = "" ]; then
+      continue
+    fi
 
-  if ! [[ "${syscall}" =~ [0-9a-zA-Z/] ]]; then
-    echo "ERROR: Entry contains invalid character: '${syscall}'"
-    continue
-  fi
+    if ! [[ "${syscall}" =~ [0-9a-zA-Z/] ]]; then
+      echo "ERROR: Entry contains invalid character: '${syscall}'"
+      continue
+    fi
 
-  if ! read -r actual_syscall arg_num syscall_arg <<< "${syscall}"; then
-    echo "ERROR: Cannot parse: '${syscall}'"
-    continue
-  fi
+    if ! read -r actual_syscall arg_num syscall_arg <<< "${syscall}"; then
+      echo "ERROR: Cannot parse: '${syscall}'"
+      continue
+    fi
 
-  if [ "${arg_num}" = "" ]; then
-    whitelisted_syscalls+="  ALLOW_SYSCALL (${syscall});
+    if [ "${actual_syscall}" = "@include" ]; then
+      generate_filter "${arg_num}"
+      continue
+    fi
+
+    if [ "${arg_num}" = "" ]; then
+      whitelisted_syscalls+="  ALLOW_SYSCALL (${syscall});
 "
-    continue
-  fi
+      continue
+    fi
 
-  if ! [ "${arg_num}" = "0" ] && ! [ "${arg_num}" = "1" ] && ! [ "${arg_num}" = "2" ]; then
-    echo "ERROR: Not a valid argument number: ${arg_num}"
-    continue
-  fi
+    if ! [ "${arg_num}" = "0" ] && ! [ "${arg_num}" = "1" ] && ! [ "${arg_num}" = "2" ]; then
+      echo "ERROR: Not a valid argument number: ${arg_num}"
+      continue
+    fi
 
-  if [ "${actual_syscall}" = "ioctl" ]; then
-    ## TODO: Can we remove this exception without opening up holes?
-    whitelisted_syscalls+="  ALLOW_IOCTL (${syscall_arg});
+    if [ "${actual_syscall}" = "ioctl" ]; then
+      ## TODO: Can we remove this exception without opening up holes?
+      whitelisted_syscalls+="  ALLOW_IOCTL (${syscall_arg});
 "
-  else
-    whitelisted_syscalls+="  ALLOW_ARG${arg_num} (${actual_syscall}, ${syscall_arg});
+    else
+      whitelisted_syscalls+="  ALLOW_ARG${arg_num} (${actual_syscall}, ${syscall_arg});
 "
-  fi
-done < "${whitelist_file}"
+    fi
+  done < "${1}"
+}
+
+generate_filter "${whitelist_file}"
 
 echo "#include <seccomp.h>
 #include <unistd.h>

--- a/usr/share/sandbox-app-launcher/seccomp-whitelist
+++ b/usr/share/sandbox-app-launcher/seccomp-whitelist
@@ -380,10 +380,3 @@ shmat 2 0
 shmat 2 SHM_RND
 shmat 2 SHM_RDONLY
 shmat 2 SHM_REMAP
-
-## Disable W^X.
-#mmap
-#mmap2
-#mprotect
-#pkey_mprotect
-#shmat

--- a/usr/share/sandbox-app-launcher/seccomp-whitelist-wx
+++ b/usr/share/sandbox-app-launcher/seccomp-whitelist-wx
@@ -1,0 +1,11 @@
+## Copyright (C) 2012 - 2020 ENCRYPTED SUPPORT LP <adrelanos@riseup.net>
+## See the file COPYING for copying conditions.
+
+@include /usr/share/sandbox-app-launcher/seccomp-whitelist
+
+## Disable W^X.
+mmap
+mmap2
+mprotect
+pkey_mprotect
+shmat


### PR DESCRIPTION
This adds support for include statements to autogen-seccomp and uses that for seccomp-whitelist-wx rather than having the main script copy and modify it which simplifies it a bit.