### PR TITLE
Permit FICLONE and SIOCGIWMODE ioctls

### DIFF
--- a/usr/share/sandbox-app-launcher/autogen-seccomp
+++ b/usr/share/sandbox-app-launcher/autogen-seccomp
@@ -82,6 +82,8 @@ echo "#include <seccomp.h>
 #include <linux/shm.h>
 #include <linux/random.h>
 #include <linux/vt.h>
+#include <linux/fs.h>
+#include <linux/wireless.h>
 
 #define ALLOW_SYSCALL(call) { if (seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS(call), 0) < 0) goto out; }
 #define ALLOW_IOCTL(call) { if (seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS(ioctl), 1, SCMP_A1 (SCMP_CMP_MASKED_EQ, 0xFFFFFFFFu, (int) call), 0) < 0) goto out; }

--- a/usr/share/sandbox-app-launcher/seccomp-whitelist
+++ b/usr/share/sandbox-app-launcher/seccomp-whitelist
@@ -115,10 +115,12 @@ inotify_add_watch
 inotify_init
 inotify_init1
 inotify_rm_watch
+ioctl 1 FICLONE
 ioctl 1 FIOCLEX
 ioctl 1 FIONBIO
 ioctl 1 FIONREAD
 ioctl 1 RNDGETENTCNT
+ioctl 1 SIOCGIWMODE
 ioctl 1 TCGETS
 ioctl 1 TCSETS
 ioctl 1 TCSETSW


### PR DESCRIPTION
These don't seem dangerous and are required by Telegram and likely other apps.